### PR TITLE
Defines files of resolved configuration as inputs

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK 15
       uses: actions/setup-java@v2
       with:
-        java-version: '11'
+        java-version: '15'
         distribution: 'adopt'
         cache: gradle
     - name: Grant execute permission for gradlew

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
     - $HOME/.gradle/wrapper/
 
 jdk:
-  - oraclejdk15
+  - oraclejdk20
   
 dist: precise
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
     - $HOME/.gradle/wrapper/
 
 jdk:
-  - oraclejdk20
+  - oraclejdk15
   
 dist: precise
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
     - $HOME/.gradle/wrapper/
 
 jdk:
-  - oraclejdk8
+  - oraclejdk15
   
 dist: precise
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # RELEASE NOTES
 
+- 1.10
+
+  - Uses files from configured configurations as inputs in order to skip execution if nothing changed.
+
+
 - 1.9
 
   - Changed the log level of _logger.warn("classpathHell: trace=" + doTrace)_ to info so it doesn't clutter the console.

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,9 @@
 // RELEASNG ...
 // DO IT IN WINDOWS
 // UPDATE build.gradle: version '1.9'
+// SETUP:   plug gnupg contents into C:/Users/johnl/AppData/Roaming/gnupg
 // SETUP:   place gradle.properties in c:\users\johnl\gradlerelease\
+// SETUP:   gradle.properties refers to the gnupg dir so adjust accordingly
 // RELEASE: .\gradlew -g c:\users\johnl\gradlerelease publishPlugins [--validate-only]
 // VERIFY:  https://plugins.gradle.org/plugin/com.portingle.classpath-hell
 
@@ -114,7 +116,7 @@ task runDemoFail(type: Exec) {
 }
 
 test.dependsOn(['createPluginClasspath'])
-test.finalizedBy(['runDemoPass','runDemoFail'])
+build.finalizedBy(['runDemoPass','runDemoFail'])
 
 
 publishing {
@@ -158,8 +160,8 @@ publishing {
     }
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_15
+targetCompatibility = JavaVersion.VERSION_15
 
 
 gradlePlugin {

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ plugins {
 
 group 'com.portingle'
 archivesBaseName = "classpath-hell"
-version '1.9'
+version '1.10'
 
 repositories {
     mavenCentral()
@@ -32,7 +32,7 @@ dependencies {
 
     testImplementation(gradleTestKit())
 
-    testImplementation group: 'junit', name: 'junit', version: '4.11'
+    testImplementation group: 'junit', name: 'junit', version: '4.13.1'
 }
 
 

--- a/src/test/groovy/classpathHell/ClasspathHellPluginTests.groovy
+++ b/src/test/groovy/classpathHell/ClasspathHellPluginTests.groovy
@@ -365,13 +365,16 @@ class ClasspathHellPluginTests {
                 .withArguments("--info", 'checkClasspath')
                 .withPluginClasspath(pluginClasspath)
 
+        println("===================================== FIRST RUN")
         BuildResult result = runner.build()
-        def output = result.getOutput()
+        assertTrue(result.getOutput().contains('classpathHell: checking resource'))
         assertEquals("First run should result in SUCCESS", SUCCESS, result.task(":checkClasspath").getOutcome())
 
         // second run: Task should be skipped since dependencies did not change:
+
+        println("===================================== SECOND RUN")
         result = runner.build()
-        output = result.getOutput()
+        assertFalse(result.getOutput().contains('classpathHell: checking resource'))
         assertEquals("Second run should result in UP_TO_DATE", UP_TO_DATE, result.task(":checkClasspath").getOutcome())
 
     }
@@ -390,14 +393,18 @@ class ClasspathHellPluginTests {
                 .withArguments("--info", 'checkClasspath')
                 .withPluginClasspath(pluginClasspath)
 
+        println("===================================== FIRST RUN")
         BuildResult result = runner.build()
+        assertTrue(result.getOutput().contains('classpathHell: checking resource'))
         assertEquals("First run should result in SUCCESS", SUCCESS, result.task(":checkClasspath").getOutcome())
 
         // Change dependencies for second run (upgrade hamcrest dependency)
         writeBuildFile("1.3", false)
 
         // second run: Task should be skipped since dependencies did not change:
+        println("===================================== SECOND RUN")
         result = runner.build()
+        assertTrue(result.getOutput().contains('classpathHell: checking resource'))
         assertEquals("Second run should result in SUCCESS", SUCCESS, result.task(":checkClasspath").getOutcome())
     }
 
@@ -416,11 +423,15 @@ class ClasspathHellPluginTests {
                 .withArguments("--info", 'checkClasspath')
                 .withPluginClasspath(pluginClasspath)
 
+        println("===================================== FIRST RUN")
         BuildResult result = runner.buildAndFail()
+        assertTrue(result.getOutput().contains('classpathHell: checking resource'))
         assertEquals("First run should result in FAILED", FAILED, result.task(":checkClasspath").getOutcome())
 
         // second run: task should not be skipped since the last run failed!:
+        println("===================================== SECOND RUN")
         result = runner.buildAndFail()
+        assertTrue(result.getOutput().contains('classpathHell: checking resource'))
         assertEquals("Second run should result in FAILED", FAILED, result.task(":checkClasspath").getOutcome())
 
     }


### PR DESCRIPTION
That makes it possible to skip execution if no duplicates were found and the configurations did not change.